### PR TITLE
Added functional options to provide a clean and configurable API

### DIFF
--- a/dicom_test.go
+++ b/dicom_test.go
@@ -3,7 +3,6 @@ package dicom
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 )
@@ -23,18 +22,15 @@ func init() {
 			fmt.Println("failed to read file")
 			panic(err)
 		}
-		files = append(files, file)
 
+		files = append(files, file)
 	}
 }
 
 func BenchmarkParseSingle(b *testing.B) {
-	dict, err := os.Open("dicom.dic")
-	defer dict.Close()
-	if err != nil {
-		panic(err)
-	}
-	parser, err := NewParser(dict)
+
+	parser, _ := NewParser()
+
 	for i := 0; i < b.N; i++ {
 		_, err := parser.Parse(files[0])
 		if err != nil {
@@ -45,12 +41,9 @@ func BenchmarkParseSingle(b *testing.B) {
 }
 
 func BenchmarkParseMultiple(b *testing.B) {
-	dict, err := os.Open("dicom.dic")
-	defer dict.Close()
-	if err != nil {
-		panic(err)
-	}
-	parser, err := NewParser(dict)
+
+	parser, _ := NewParser()
+
 	for i := 0; i < b.N; i++ {
 		for _, file := range files {
 			_, err := parser.Parse(file)

--- a/dictionary.go
+++ b/dictionary.go
@@ -56,14 +56,14 @@ func Dictionary(r io.Reader) func(*Parser) error {
 			dictionary[group][element] = &dictEntry{row[1], row[2], row[3], row[4]}
 		}
 
-		p.Dictionary = dictionary
+		p.dictionary = dictionary
 		return nil
 	}
 
 }
 
 func (p *Parser) getDictEntry(group, element int) (*dictEntry, error) {
-	entry := p.Dictionary[group][element]
+	entry := p.dictionary[group][element]
 	if entry == nil {
 		return nil, ErrTagNotFound
 	}

--- a/dictionary_test.go
+++ b/dictionary_test.go
@@ -2,22 +2,13 @@ package dicom
 
 import (
 	"fmt"
-	"os"
 	"testing"
 )
 
 var parser *Parser
 
 func init() {
-	dict, err := os.Open("dicom.dic")
-	defer dict.Close()
-	if err != nil {
-		panic(err)
-	}
-	parser, err = NewParser(dict)
-	if err != nil {
-		panic(err)
-	}
+	parser, _ = NewParser()
 }
 
 func BenchmarkFindMetaGroupLengthTag(b *testing.B) {

--- a/examples/configuration.go
+++ b/examples/configuration.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"github.com/gillesdemey/go-dicom"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+func main() {
+
+	fh, err := os.Open("dicom.dic")
+	defer fh.Close()
+
+	dict := dicom.Dictionary(fh)
+
+	parser, err := dicom.NewParser(dict)
+
+	if err != nil {
+		panic(err)
+	}
+
+	// parse all DICOM files
+	files, _ := filepath.Glob("examples/*.dcm")
+
+	for _, path := range files {
+
+		file, err := ioutil.ReadFile(path)
+
+		if err != nil {
+			panic(err)
+		}
+
+		data, err := parser.Parse(file)
+
+		if err != nil {
+			fmt.Println(err)
+		}
+
+		elem, _ := data.LookupElement("PatientName")
+		name := elem.Value
+		fmt.Printf("Patient name: %s\n", name)
+
+	}
+
+}

--- a/examples/simple.go
+++ b/examples/simple.go
@@ -4,19 +4,12 @@ import (
 	"fmt"
 	"github.com/gillesdemey/go-dicom"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 )
 
 func main() {
 
-	dict, err := os.Open("dicom.dic")
-	defer dict.Close()
-	if err != nil {
-		panic(err)
-	}
-
-	parser, err := dicom.NewParser(dict)
+	parser, err := dicom.NewParser()
 
 	if err != nil {
 		panic(err)
@@ -39,9 +32,9 @@ func main() {
 			fmt.Println(err)
 		}
 
-		for _, elem := range data.Elements {
-			fmt.Printf("%+v\n", &elem)
-		}
+		elem, _ := data.LookupElement("PatientName")
+		name := elem.Value
+		fmt.Printf("Patient name: %s\n", name)
 
 	}
 

--- a/parser.go
+++ b/parser.go
@@ -30,7 +30,7 @@ type DicomElement struct {
 }
 
 type Parser struct {
-	Dictionary [][]*dictEntry
+	dictionary [][]*dictEntry
 }
 
 // Return the tag as a string to use in the Dicom dictionary


### PR DESCRIPTION
Use it with it's default behaviour (obvious pseudo-code):

``` Go
parser, err := dicom.NewParser()
parser.Parse("file.dcm")
```

or with a custom configuration

``` Go
fh, err := os.Open("dicom.dic")
defer fh.Close()

parser, err := dicom.NewParser(
  dicom.Dictionary(fh),
)

parser.Parse("file.dcm")
```

You can supply as many options as you want, in any order. 

And no nil values required.
