### PR TITLE
Return file info from channel in struct

### DIFF
--- a/dicom.go
+++ b/dicom.go
@@ -7,6 +7,7 @@ import (
 
 type DicomFile struct {
 	Elements []DicomElement
+	Path string
 }
 
 // Errors

--- a/dicomPipes.go
+++ b/dicomPipes.go
@@ -48,6 +48,21 @@ func (di *DicomFile) Discard(in <-chan DicomMessage, done *sync.WaitGroup) {
 
 }
 
+// Discard messages and not store pixel data
+func (di *DicomFile) DiscardPixel(in <-chan DicomMessage, done *sync.WaitGroup) {
+	done.Add(1)
+	go func() {
+		for dcmMsg := range in {
+			dcmMsg.wait <- true
+			if dcmMsg.msg.Name != "PixelData" {
+				di.Elements = append(di.Elements, *dcmMsg.msg)
+			}
+		}
+		done.Done()
+	}()
+
+}
+
 func fileName(folder string, i int, ext string) string {
 	basename := fp.Base(folder)
 	filename := basename + "_" + fmt.Sprintf("%03d\n", i)

--- a/dicomPipes.go
+++ b/dicomPipes.go
@@ -27,10 +27,11 @@ func (di *DicomFile) Parse(buff []byte) <-chan DicomMessage {
 		panic(err)
 	}
 
-	_, c := parser.Parse(buff)
+	di, c := parser.Parse(buff)
 	if err != nil {
 		panic(err)
 	}
+
 	return c
 }
 
@@ -40,6 +41,7 @@ func (di *DicomFile) Discard(in <-chan DicomMessage, done *sync.WaitGroup) {
 	go func() {
 		for dcmMsg := range in {
 			dcmMsg.wait <- true
+			di.Elements = append(di.Elements, *dcmMsg.msg)
 		}
 		done.Done()
 	}()


### PR DESCRIPTION
Hi, I've been working on this library and made a few useful changes regarding the return of the dicom file header from the Parse functions in dicomPipes.go and dicom.go so that the returned dicomFile has the parsed dicomElements stored from the dicomMessage channel. This would allow users of the library to interact with the file headers rather than only being able to view a log of them, the former being a more probable use case.